### PR TITLE
fix jademod.js to work with npm local installation

### DIFF
--- a/bin/jademod.js
+++ b/bin/jademod.js
@@ -72,5 +72,5 @@ yor.enable(true);
 
 //
 // run the jade cli.
-require('../node_modules/jade/bin/jade');
+require('jade/bin/jade');
 


### PR DESCRIPTION
phpjadeを便利に使わせて頂いております。

どうしてもグローバルインストールが好きではなかったため
ローカルインストールでも動くように修正してみました。
適当なディレクトリで以下のコマンドで動作しました。

npm install jade
npm install jade-mod
node_modules/.bin/jademod -M phpjade
